### PR TITLE
Fix for Entity:has not returning false if the component doesn't exist

### DIFF
--- a/fluid/entity.lua
+++ b/fluid/entity.lua
@@ -71,7 +71,7 @@ end
 -- @params component The Component to check against
 -- @return True if the entity has the Bag. False otherwise
 function Entity:has(component)
-   return self.components[component] and true
+   return self.components[component] ~= nil
 end
 
 return setmetatable(Entity, {


### PR DESCRIPTION
The documentation states that Entity:has will return false if the component doesn't exist and true if it does.
However, the previous behaviour was to return nil if the component doesn't exist.