### PR TITLE
Fixed removed list not being cleared

### DIFF
--- a/fluid/entity.lua
+++ b/fluid/entity.lua
@@ -45,6 +45,7 @@ function Entity:apply()
 
    for component, _ in pairs(self.removed) do
       self.components[component] = nil
+      self.removed[component] = nil
    end
 
    return self


### PR DESCRIPTION
After an entity has a component removed from it, the apply function wasn't removing it from the removed list.
This had weird side-effects like the inability to readd components after they were removed.

For example:
```lua
entity:give(Foo):apply()
entity:remove(Foo):apply()
entity:give(Foo):apply() -- This line would fail to add the Foo component again.
```